### PR TITLE
changes to allow topics dropdown to auto-update

### DIFF
--- a/__tests__/SelectorUnitTests.ts
+++ b/__tests__/SelectorUnitTests.ts
@@ -6,6 +6,10 @@ configure({ adapter: new Adapter() });
 
 describe('Selector unit tests', () => {
   const props = {
+    setGraphIntervalId: jest.fn(),
+    setTableIntervalId: jest.fn(),
+    tableIntervalId: null,
+    graphIntervalId: null,
     setData: jest.fn(),
     setTopic: jest.fn(),
     serverList: ['test_test'],

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -12,6 +12,7 @@ const App = (): JSX.Element => {
   const [topicList, setTopicList] = React.useState<string[]>([]);
   const [bootstrap, setBootstrap] = React.useState<string>('');
   const [serverList, setServerList] = React.useState<string[]>([]);
+  console.log(bootstrap);
   //graph rendering state ->
   const [data, setData] = React.useState<
     Array<{ time: number; value: number }>

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -3,6 +3,10 @@ import LoginPage from './LoginPage';
 import Graph from './Graph';
 import Selector from './Selector';
 const App = (): JSX.Element => {
+  const [graphIntervalId, setGraphInvervalId] =
+    React.useState<NodeJS.Timeout | null>(null);
+  const [tableIntervalId, setTableIntervalId] =
+    React.useState<NodeJS.Timeout | null>(null);
   const [loginStatus, changeLoginStatus] = React.useState<boolean>(true);
   const [loginAttempt, changeAttempt] = React.useState<string | null>(null);
   const [currentUser, changeUser] = React.useState<string>();
@@ -98,6 +102,10 @@ const App = (): JSX.Element => {
       return (
         <div key='selector'>
           <Selector
+            graphIntervalId={graphIntervalId}
+            setGraphIntervalId={setGraphInvervalId}
+            tableIntervalId={tableIntervalId}
+            setTableIntervalId={setTableIntervalId}
             setData={setData}
             setTopic={setTopic}
             bootstrap={bootstrap}

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -3,7 +3,8 @@ import LoginPage from './LoginPage';
 import Graph from './Graph';
 import Selector from './Selector';
 const App = (): JSX.Element => {
-  const [loginStatus, changeLoginStatus] = React.useState<boolean>(false);
+  console.log('rendering app');
+  const [loginStatus, changeLoginStatus] = React.useState<boolean>(true);
   const [loginAttempt, changeAttempt] = React.useState<string | null>(null);
   const [currentUser, changeUser] = React.useState<string>();
   const [rendering, setRendering] = React.useState<boolean>(false);
@@ -86,7 +87,7 @@ const App = (): JSX.Element => {
   if (!rendering) {
     if (loginStatus === false) {
       return (
-        <div>
+        <div key='loginPage'>
           <LoginPage
             loginButton={loginButton}
             signUp={signUp}
@@ -96,7 +97,7 @@ const App = (): JSX.Element => {
       );
     } else if (loginStatus === true) {
       return (
-        <div>
+        <div key='selector'>
           <Selector
             setData={setData}
             setTopic={setTopic}
@@ -112,7 +113,7 @@ const App = (): JSX.Element => {
       );
     }
   }
-  return <div>Loading, please wait!</div>;
+  return <div key='loadingMessage'>Loading, please wait!</div>;
 };
 
 export default App;

--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -3,7 +3,6 @@ import LoginPage from './LoginPage';
 import Graph from './Graph';
 import Selector from './Selector';
 const App = (): JSX.Element => {
-  console.log('rendering app');
   const [loginStatus, changeLoginStatus] = React.useState<boolean>(true);
   const [loginAttempt, changeAttempt] = React.useState<string | null>(null);
   const [currentUser, changeUser] = React.useState<string>();
@@ -12,7 +11,6 @@ const App = (): JSX.Element => {
   const [topicList, setTopicList] = React.useState<string[]>([]);
   const [bootstrap, setBootstrap] = React.useState<string>('');
   const [serverList, setServerList] = React.useState<string[]>([]);
-  console.log(bootstrap);
   //graph rendering state ->
   const [data, setData] = React.useState<
     Array<{ time: number; value: number }>

--- a/client/components/Graph.tsx
+++ b/client/components/Graph.tsx
@@ -51,24 +51,15 @@ const Graph = ({ data }: Props): JSX.Element => {
       .domain([dataValueMax, dataValueMin])
       .range([0, height - margin.top - margin.bottom]);
     //creating the function that will take in the data and produce the path element
-    const line = d3
+    const histogram = d3
       .line<typeof data[0]>()
-      .defined((d) => d.value !== null)
-      .curve(d3.curveBasis)
-      .x((d) => xScale(d.time))
-      .y((d) => yScale(d.value));
+      .value((d) => d)
+      .domain([dataTimeMin, dataTimeMax])
+      .thresholds(xScale.ticks(70));
+    const bins = histogram(data.map((el) => el.value));
     //putting the data into svg and moving it around according to the margin
-    svg
-      .attr('width', width)
-      .attr('height', height)
-      .append('path')
-      .data(data)
-      .attr('transform', `translate(${margin.left}, ${margin.bottom})`)
-      .attr('fill', 'none')
-      .attr('stroke', '#000')
-      .attr('stroke-width','2px')
-      .attr('class', 'line')
-      .attr('d', line(data));
+    svg.attr('width', width).attr('height', height);
+
     //defining the xaxis from the scales
     const xAxis = d3.axisBottom(xScale);
     const yAxis = d3.axisLeft(yScale);
@@ -81,7 +72,7 @@ const Graph = ({ data }: Props): JSX.Element => {
       //adding label
       .append('text')
       .attr('class', 'axis-label')
-      .text('Partition Index')
+      .text('Number of partitions')
       .attr('x', width - 140)
       .attr('y', 25); // Relative to the x axis.
     svg
@@ -96,6 +87,23 @@ const Graph = ({ data }: Props): JSX.Element => {
       .attr('transform', 'rotate(-90)')
       .attr('x', -75)
       .attr('y', -25); // Relative to the y axis.
+
+    svg
+      .selectAll('rect')
+      .data(bins)
+      .enter()
+      .append('rect')
+      .attr('x', 1)
+      .attr('transform', function (d) {
+        return 'translate(' + xScale(d.x0!) + ',' + yScale(d.length) + ')';
+      })
+      .attr('width', function (d) {
+        return xScale(d.x1!) - xScale(d.x0) - 1;
+      })
+      .attr('height', function (d) {
+        return height - yScale(d.length);
+      })
+      .style('fill', '#69b3a2');
   }
   return (
     <div>

--- a/client/components/Graph.tsx
+++ b/client/components/Graph.tsx
@@ -51,15 +51,24 @@ const Graph = ({ data }: Props): JSX.Element => {
       .domain([dataValueMax, dataValueMin])
       .range([0, height - margin.top - margin.bottom]);
     //creating the function that will take in the data and produce the path element
-    const histogram = d3
+    const line = d3
       .line<typeof data[0]>()
-      .value((d) => d)
-      .domain([dataTimeMin, dataTimeMax])
-      .thresholds(xScale.ticks(70));
-    const bins = histogram(data.map((el) => el.value));
+      .defined((d) => d.value !== null)
+      .curve(d3.curveBasis)
+      .x((d) => xScale(d.time))
+      .y((d) => yScale(d.value));
     //putting the data into svg and moving it around according to the margin
-    svg.attr('width', width).attr('height', height);
-
+    svg
+      .attr('width', width)
+      .attr('height', height)
+      .append('path')
+      .data(data)
+      .attr('transform', `translate(${margin.left}, ${margin.bottom})`)
+      .attr('fill', 'none')
+      .attr('stroke', '#000')
+      .attr('stroke-width', '2px')
+      .attr('class', 'line')
+      .attr('d', line(data));
     //defining the xaxis from the scales
     const xAxis = d3.axisBottom(xScale);
     const yAxis = d3.axisLeft(yScale);
@@ -72,7 +81,7 @@ const Graph = ({ data }: Props): JSX.Element => {
       //adding label
       .append('text')
       .attr('class', 'axis-label')
-      .text('Number of partitions')
+      .text('Partition Index')
       .attr('x', width - 140)
       .attr('y', 25); // Relative to the x axis.
     svg
@@ -87,30 +96,8 @@ const Graph = ({ data }: Props): JSX.Element => {
       .attr('transform', 'rotate(-90)')
       .attr('x', -75)
       .attr('y', -25); // Relative to the y axis.
-
-    svg
-      .selectAll('rect')
-      .data(bins)
-      .enter()
-      .append('rect')
-      .attr('x', 1)
-      .attr('transform', function (d) {
-        return 'translate(' + xScale(d.x0!) + ',' + yScale(d.length) + ')';
-      })
-      .attr('width', function (d) {
-        return xScale(d.x1!) - xScale(d.x0) - 1;
-      })
-      .attr('height', function (d) {
-        return height - yScale(d.length);
-      })
-      .style('fill', '#69b3a2');
   }
-  return (
-    <div>
-      {!!data.length && <h2>Graph</h2>}
-      <div id='mainContainer'></div>
-    </div>
-  );
+  return <div id='mainContainer'>{!!data.length && <h2>Graph</h2>}</div>;
 };
 
 export default Graph;

--- a/client/components/Selector.tsx
+++ b/client/components/Selector.tsx
@@ -24,6 +24,16 @@ const Selector = ({
   bootstrap,
   setBootstrap,
 }: Props): JSX.Element => {
+  const updateTables = (): void => {
+    axios({
+      method: 'post',
+      url: 'http://localhost:3001/kafka/updateTables',
+      data: { bootstrap },
+    }).then((response) => {
+      const temp: { topic: string }[] = [...response.data];
+      setTopicList(temp.map((el) => el.topic));
+    });
+  };
   //below creates an array filled with options for the bootstrap servers
   const serverListArr: JSX.Element[] = [];
   for (let i = 0; i < serverList.length; i++) {
@@ -146,6 +156,7 @@ const Selector = ({
     } else {
       //this is if the option chosen is the blank option
       setData([]);
+      setInterval(updateTables, 10000);
     }
   };
   if (process.env.NODE_ENV !== 'testing') {

--- a/client/components/Selector.tsx
+++ b/client/components/Selector.tsx
@@ -25,15 +25,20 @@ const Selector = ({
   setBootstrap,
 }: Props): JSX.Element => {
   const updateTables = (): void => {
-    console.log(bootstrap);
+    console.log('from update');
     if (bootstrap.length) {
       axios({
         method: 'post',
         url: 'http://localhost:3001/kafka/updateTables',
         data: { bootstrap },
+      }).then((response) => {
+        console.log(response.data);
+        const temp: { topic: string }[] = [...response.data];
+        setTopicList(temp.map((el) => el.topic));
       });
     }
   };
+
   //below creates an array filled with options for the bootstrap servers
   const serverListArr: JSX.Element[] = [];
   for (let i = 0; i < serverList.length; i++) {
@@ -98,6 +103,7 @@ const Selector = ({
       setBootstrap(newBootstrap?.value.replace('_', ':'));
       fetchTopics(newBootstrap?.value);
     }
+    updateTables();
   };
   //sends a request to backend to grab topics for passed in bootstrap server
   const fetchTopics = (arg: string) => {
@@ -141,6 +147,7 @@ const Selector = ({
         });
       //setting interval of same request above so we autorefresh it (pull model)
       const intervalId = window.setInterval(() => {
+        updateTables();
         axios({
           method: 'POST',
           url: 'http://localhost:3001/kafka/refresh',
@@ -164,11 +171,10 @@ const Selector = ({
     React.useEffect(() => {
       fetchTables();
       console.log('literally anything');
-      window.setInterval(updateTables, 1000);
     }, []);
   }
   return (
-    <div className='mainWrapper'>
+    <div id='mainWrapper'>
       <div className='headingWrapper'>
         <h1 className='heading'>Saamsa</h1>
       </div>

--- a/client/components/Selector.tsx
+++ b/client/components/Selector.tsx
@@ -25,14 +25,14 @@ const Selector = ({
   setBootstrap,
 }: Props): JSX.Element => {
   const updateTables = (): void => {
-    axios({
-      method: 'post',
-      url: 'http://localhost:3001/kafka/updateTables',
-      data: { bootstrap },
-    }).then((response) => {
-      const temp: { topic: string }[] = [...response.data];
-      setTopicList(temp.map((el) => el.topic));
-    });
+    console.log(bootstrap);
+    if (bootstrap.length) {
+      axios({
+        method: 'post',
+        url: 'http://localhost:3001/kafka/updateTables',
+        data: { bootstrap },
+      });
+    }
   };
   //below creates an array filled with options for the bootstrap servers
   const serverListArr: JSX.Element[] = [];
@@ -92,6 +92,7 @@ const Selector = ({
     const newBootstrap: HTMLSelectElement | null = document.querySelector(
       '#bootstrap option:checked'
     );
+    console.log(newBootstrap?.value);
     if (newBootstrap?.value.length) {
       //updating state here to cause rerender
       setBootstrap(newBootstrap?.value.replace('_', ':'));
@@ -123,6 +124,7 @@ const Selector = ({
     ); //grabbing current selected topic
     if (newTopic?.value.length) setTopic(newTopic?.value); //checking if user selected blank topic (if so, graph should disappear)
     if (bootstrap.length && newTopic?.value.length) {
+      console.log(bootstrap);
       //making initial request so we instantly update the data
       axios({
         method: 'POST',
@@ -156,13 +158,13 @@ const Selector = ({
     } else {
       //this is if the option chosen is the blank option
       setData([]);
-      setInterval(updateTables, 10000);
     }
   };
   if (process.env.NODE_ENV !== 'testing') {
     React.useEffect(() => {
-      console.log('hereee');
       fetchTables();
+      console.log('literally anything');
+      window.setInterval(updateTables, 1000);
     }, []);
   }
   return (

--- a/client/scss/LoginPage.scss
+++ b/client/scss/LoginPage.scss
@@ -1,15 +1,14 @@
-
-@import "_variables";
-body { 
-    background-color: $saamsaYellow;
-    background-repeat: no-repeat;
-    background-position-x: center;
-    margin: 0px;
-    width: 100%;
-    height: 100%;
-    // background-image: url('https://media.discordapp.net/attachments/890965712405946428/898253886811418634/roach_hat.png?width=722&height=722');
-    // background-attachment: fixed;
-    // background-position: center;
+@import '_variables';
+body {
+  background-color: $saamsaYellow;
+  background-repeat: no-repeat;
+  background-position-x: center;
+  margin: 0px;
+  width: 100%;
+  height: 100%;
+  // background-image: url('https://media.discordapp.net/attachments/890965712405946428/898253886811418634/roach_hat.png?width=722&height=722');
+  // background-attachment: fixed;
+  // background-position: center;
 }
 .headingWrapper {
   background-color: $saamsaGrey;
@@ -20,116 +19,113 @@ body {
   // align-items: center;
   // text-align:center;
 }
-.saamsaLogo{
+.saamsaLogo {
   width: 450px;
   height: 450px;
   position: fixed;
   bottom: 0;
 }
-.heading{
+.heading {
   font-size: 60px;
-  color: $saamsaBlack ;
+  color: $saamsaBlack;
   opacity: 1;
-  margin-bottom:40px;
+  margin-bottom: 40px;
   margin-top: 0;
   font-family: $fontTitle;
-  line-height:51px;
-  vertical-align:middle;
+  line-height: 51px;
+  vertical-align: middle;
 }
-.loginTitle{
-    font-family: $fontTitle;
-    font-size: 30px;
-    position: relative;
-    left: 5px;
-    float:left;
-    margin-left: 7px;
-}
-
-.loginWrapper{
- 
-    display: flex;
-    flex-direction: column;
-    align-items:flex-start;
-    background-color: $saamsaWhite;
-    width: 220px;
-    height: 320px;
-    margin-top: 25%; 
-    margin-left: 60%; 
-    border: 2px solid black;
+.loginTitle {
+  font-family: $fontTitle;
+  font-size: 30px;
+  position: relative;
+  left: 5px;
+  float: left;
+  margin-left: 7px;
 }
 
-.inputFields{
-  border:none;
+.loginWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  background-color: $saamsaWhite;
+  width: 220px;
+  height: 320px;
+  margin-top: 25%;
+  margin-left: 60%;
+  border: 2px solid black;
+}
+
+.inputFields {
+  border: none;
   border-bottom: 2px solid black;
   width: 200px;
   margin-left: 7px;
 }
-
-#usernameAndPasswordWrapper{
-        display: flex;
-        flex-direction: column;
-        gap: 40px;
-        align-items: center;
-        margin-bottom: 20px;
-        margin-top: 20px;
-        border: none;
-        // border-bottom: 2px solid red;
+#usernameAndPasswordWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  align-items: center;
+  margin-bottom: 20px;
+  margin-top: 20px;
+  border: none;
+  // border-bottom: 2px solid red;
 }
 
 #buttonsDiv {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 10px;
-    margin-left: 7px;
-  }
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-left: 7px;
+}
 
-  #forgotPassword {
-    color: #313A46;
-    font-family: Verdana, Geneva, Tahoma, sans-serif;
-    font-size: 12px;
-    background-color: transparent;
-    border-color: transparent;
-    margin-left: 7px;
-  }
-  // h2 {
-  //   margin-top: 30px;
-  //   color: #313A46;
-  //   font-family: Verdana, Geneva, Tahoma, sans-serif;
-  //   font-size: 12px;
-  // }
-  #loginBtn{
-    border-radius: 4px;
-    background-color: $saamsaYellow;
-    border: 1px solid black;
-    height: 30px;
-    font-size: 15px;
-    font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
-    color: $saamsaBlack;
-    width: 200px;
-  }
-  #noAccount{
-    font-size: 10px;
-    font-family: $buttonTitle;
-
-  }
+#forgotPassword {
+  color: #313a46;
+  font-family: Verdana, Geneva, Tahoma, sans-serif;
+  font-size: 12px;
+  background-color: transparent;
+  border-color: transparent;
+  margin-left: 7px;
+}
+// h2 {
+//   margin-top: 30px;
+//   color: #313A46;
+//   font-family: Verdana, Geneva, Tahoma, sans-serif;
+//   font-size: 12px;
+// }
+#loginBtn {
+  border-radius: 4px;
+  background-color: $saamsaYellow;
+  border: 1px solid black;
+  height: 30px;
+  font-size: 15px;
+  font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
+  color: $saamsaBlack;
+  width: 200px;
+}
+#noAccount {
+  font-size: 10px;
+  font-family: $buttonTitle;
+}
 #signUpArea {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-around;
-  }
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-around;
+}
 
-  #signUpBtn {
-    border-radius: 4px;
-    background-color: transparent;
-    border: 0px transparent;
-    width: 70px;
-    height: 30px;
-    font-size: 10px;
-    font-family: $buttonTitle;
-    color: $saamsaBlack;
-  }
-  #signupBtn:hover {
-    cursor: pointer;
-  }
+#signUpBtn {
+  border-radius: 4px;
+  background-color: transparent;
+  border: 0px transparent;
+  width: 70px;
+  height: 30px;
+  font-size: 10px;
+  font-family: $buttonTitle;
+  color: $saamsaBlack;
+}
+#signupBtn:hover {
+  cursor: pointer;
+}

--- a/client/server/kafkaController.ts
+++ b/client/server/kafkaController.ts
@@ -64,11 +64,10 @@ const controller: controller = {
                       ).catch(() => {
                         console.log('a testt');
                         db.exec(`DROP TABLE ${bootstrapSanitized}`).then(() => {
-                          res.redirect(
+                          return res.redirect(
                             307,
                             'http://localhost:3001/kafka/createTable'
                           );
-                          return next();
                         });
                       });
                     } catch (error) {
@@ -79,8 +78,10 @@ const controller: controller = {
               })
               .catch(() => {
                 console.log('a testt');
-                res.redirect(307, 'http://localhost:3001/kafka/createTable');
-                return next();
+                return res.redirect(
+                  307,
+                  'http://localhost:3001/kafka/createTable'
+                );
               });
           });
         }
@@ -102,7 +103,7 @@ const controller: controller = {
       }).then((db) =>
         db
           .all(`SELECT topic FROM ${bootstrapSanitized}`)
-          .then((result) => res.status(200).json(result))
+          .then((result) => res.json(result))
       );
     } catch (error) {
       console.log(error);
@@ -118,7 +119,7 @@ const controller: controller = {
           db.all(
             "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%';"
           ).then((result) => {
-            res.status(200).json(result);
+            res.json(result);
           });
         }
       );
@@ -257,7 +258,7 @@ const controller: controller = {
                     });
                   }
                 });
-                res.status(200).json(arr);
+                res.json(arr);
               });
             });
         });

--- a/client/server/kafkaController.ts
+++ b/client/server/kafkaController.ts
@@ -44,18 +44,20 @@ const controller: controller = {
         (db) => {
           data.forEach((el) => {
             db.all(
-              `SELECT topic FROM ${bootstrapSanitized} WHERE topic=${el}`
+              `SELECT topic FROM ${bootstrapSanitized} WHERE topic='${el}';`
             ).then((result) => {
               if (result.length === 0) {
                 admin.fetchTopicOffsets(el).then((response) => {
-                  let colString = '';
-                  let valString = '';
+                  let colString = 'topic, ';
+                  let valString = `'${el}', `;
                   response.forEach((partition) => {
                     valString += `${partition.offset},`;
                     colString += `partition_${partition.partition},`;
-                    valString = valString.slice(0, valString.length - 1);
-                    colString = colString.slice(0, colString.length - 1);
                   });
+                  valString = valString.slice(0, valString.length - 1);
+                  colString = colString.slice(0, colString.length - 1);
+                  console.log(valString);
+                  console.log(colString);
                   db.exec(
                     `INSERT INTO ${bootstrapSanitized} (${colString}) VALUES (${valString});`
                   );
@@ -67,6 +69,7 @@ const controller: controller = {
       );
     });
     admin.disconnect();
+    next();
   },
   //fetches all topics for a given broker (taken from frontend broker selection)
   fetchTopics: function (req, res, next) {

--- a/client/server/kafkaController.ts
+++ b/client/server/kafkaController.ts
@@ -111,131 +111,141 @@ const controller: controller = {
   },
   //after verifying broker exists using kafkajs admin, adds each topic and it's partitions and respective offsets to sqlite
   createTable: async function (req, res, next) {
-    const { bootstrap } = req.body;
-    //if there is no server given, we send an error page
-    if (!bootstrap.length) res.sendStatus(403);
-    //sanitizing for sql
-    const bootstrapSanitized = bootstrap.replace(':', '_');
-    const instance = new kafka.Kafka({
-      clientId: 'testing2',
-      brokers: [`${bootstrap}`], //must be unsanitized form
-    });
-    const admin = instance.admin();
-    admin.connect();
-    //fetching topics for that broker
-    const results = await admin.listTopics();
-    //creating an empty object that holds offsets for each topic
-    const offsets: {
-      [key: string]: (kafka.SeekEntry & { high: string; low: string })[];
-    } = {};
-    //fetching all offsets for each partition and saving that in the offsets object
-    Promise.all(
-      results.map((el) => {
-        return admin
-          .fetchTopicOffsets(el)
-          .then((result) => (offsets[el] = result));
-      })
-    ).then(() => {
-      //getting max number of partitions for entire broker (must have for SQL, as table columns cannot be altered after creating)
-      //so each topic will have the same number of partitions in SQL db, but null values in sqldb indicate the partition does not exist on that topic in kafka
-      // topic1 w/ 3 partitions (max for broker) -> {topic: topic1, partition_0: 5, partition_1: 2, partition_3: 0}
-      // topic2 w/ 1 partition (< max for broker) -> {topic: topic2, partition_0: 10, partition_1: null, partition_3: null}
-      let maxPartitions = 0;
-      Object.keys(offsets).forEach((el) => {
-        offsets[el].forEach((el2) => {
-          if (el2.partition > maxPartitions) maxPartitions = el2.partition;
-        });
+    try {
+      const { bootstrap } = req.body;
+      //if there is no server given, we send an error page
+      if (!bootstrap.length) res.sendStatus(403);
+      //sanitizing for sql
+      const bootstrapSanitized = bootstrap.replace(':', '_');
+      const instance = new kafka.Kafka({
+        clientId: 'testing2',
+        brokers: [`${bootstrap}`], //must be unsanitized form
       });
-      //creating partition string for SQL query, creates partition_X column in db
-      let partitionString = '';
-      for (let i = 0; i <= maxPartitions; i++) {
-        if (i < maxPartitions) partitionString += `partition_${i} int,`;
-        //below is for last value, which !!!cannot!!! have comma after it
-        else partitionString += `partition_${i} int`;
-      }
-      open({ filename: '/tmp/database.db', driver: sqlite3.Database })
-        .then((db) => {
-          db.exec(
-            `CREATE TABLE ${bootstrapSanitized} (topic varchar(255), ${partitionString});`
-          );
-          return db;
+      const admin = instance.admin();
+      admin.connect();
+      //fetching topics for that broker
+      const results = await admin.listTopics();
+      //creating an empty object that holds offsets for each topic
+      const offsets: {
+        [key: string]: (kafka.SeekEntry & { high: string; low: string })[];
+      } = {};
+      //fetching all offsets for each partition and saving that in the offsets object
+      Promise.all(
+        results.map((el) => {
+          return admin
+            .fetchTopicOffsets(el)
+            .then((result) => (offsets[el] = result));
         })
-        .then((db) => {
-          Object.keys(offsets).forEach((el) => {
-            //below is for generic column names e.g. topic, partition_0, partition_1...
-            let colString = 'topic, ';
-            //below is the actual values for those columns above(!!topic must be in quotes!!) e.g. 'intial_report', 10, 7
-            let valueString = `'${el}', `;
-            offsets[el].forEach((el2) => {
-              valueString += `'${el2.offset}',`;
-              colString += `partition_${el2.partition},`;
-            });
-            valueString = valueString.slice(0, valueString.length - 1);
-            colString = colString.slice(0, colString.length - 1);
-            db.exec(
-              `INSERT INTO ${bootstrapSanitized} (${colString}) VALUES (${valueString});`
-            );
+      ).then(() => {
+        //getting max number of partitions for entire broker (must have for SQL, as table columns cannot be altered after creating)
+        //so each topic will have the same number of partitions in SQL db, but null values in sqldb indicate the partition does not exist on that topic in kafka
+        // topic1 w/ 3 partitions (max for broker) -> {topic: topic1, partition_0: 5, partition_1: 2, partition_3: 0}
+        // topic2 w/ 1 partition (< max for broker) -> {topic: topic2, partition_0: 10, partition_1: null, partition_3: null}
+        let maxPartitions = 0;
+        Object.keys(offsets).forEach((el) => {
+          offsets[el].forEach((el2) => {
+            if (el2.partition > maxPartitions) maxPartitions = el2.partition;
           });
-        })
-        .then(() => {
-          admin.disconnect();
-          next();
         });
-    });
-  },
-  //grabs data from kafka admin for a specific topic, then updates it in sqldb, then reads sqldb and sends it to frontend
-  refresh: function (req, res) {
-    const { bootstrap, topic } = req.body;
-    const bootstrapSanitized = bootstrap.replace(':', '_');
-    const instance = new kafka.Kafka({
-      brokers: [`${bootstrap}`],
-      clientId: 'testing2', //hardcoded, probably should use username from state
-    });
-    const admin = instance.admin();
-    //below is query string used to update database, does not need to be ordered e.g. (partition_43 = 0, partition_0 = 17...)
-    let setString = '';
-    admin.connect();
-    admin
-      .fetchTopicOffsets(topic)
-      .then((result) => {
-        result.forEach((el) => {
-          //adding each partitions value to the set string
-          setString += `partition_${el.partition} = ${el.offset},`;
-        });
-      })
-      .then(() => {
-        //!!important!! slicing off last comma, which will throw a SQL syntax error
-        setString = setString.slice(0, setString.length - 1);
-        open({
-          filename: '/tmp/database.db',
-          driver: sqlite3.Database,
-        })
+        //creating partition string for SQL query, creates partition_X column in db
+        let partitionString = '';
+        for (let i = 0; i <= maxPartitions; i++) {
+          if (i < maxPartitions) partitionString += `partition_${i} int,`;
+          //below is for last value, which !!!cannot!!! have comma after it
+          else partitionString += `partition_${i} int`;
+        }
+        open({ filename: '/tmp/database.db', driver: sqlite3.Database })
           .then((db) => {
             db.exec(
-              `UPDATE ${bootstrapSanitized} SET ${setString} WHERE topic='${topic}';`
+              `CREATE TABLE ${bootstrapSanitized} (topic varchar(255), ${partitionString});`
             );
             return db;
           })
-          //here we grab topic data from sqldb (after updated)
           .then((db) => {
-            db.all(
-              `SELECT * FROM ${bootstrapSanitized} WHERE topic='${topic}'`
-            ).then((result) => {
-              //new arr which holds the correctly formated data for d3
-              const arr: { time: number; value: number }[] = [];
-              Object.keys(result[0]).forEach((el) => {
-                if (el !== 'topic') {
-                  arr.push({
-                    //slicing off first part of colname and turning into number (for d3) (partition_1 -> 1)
-                    time: Number(el.slice(10)),
-                    value: result[0][el],
-                  });
-                }
+            Object.keys(offsets).forEach((el) => {
+              //below is for generic column names e.g. topic, partition_0, partition_1...
+              let colString = 'topic, ';
+              //below is the actual values for those columns above(!!topic must be in quotes!!) e.g. 'intial_report', 10, 7
+              let valueString = `'${el}', `;
+              offsets[el].forEach((el2) => {
+                valueString += `'${el2.offset}',`;
+                colString += `partition_${el2.partition},`;
               });
-              res.status(200).json(arr);
+              valueString = valueString.slice(0, valueString.length - 1);
+              colString = colString.slice(0, colString.length - 1);
+              db.exec(
+                `INSERT INTO ${bootstrapSanitized} (${colString}) VALUES (${valueString});`
+              );
             });
+          })
+          .then(() => {
+            admin.disconnect();
+            next();
           });
       });
+    } catch (error) {
+      console.log(error);
+      next(error);
+    }
+  },
+  //grabs data from kafka admin for a specific topic, then updates it in sqldb, then reads sqldb and sends it to frontend
+  refresh: function (req, res, next) {
+    try {
+      const { bootstrap, topic } = req.body;
+      const bootstrapSanitized = bootstrap.replace(':', '_');
+      const instance = new kafka.Kafka({
+        brokers: [`${bootstrap}`],
+        clientId: 'testing2', //hardcoded, probably should use username from state
+      });
+      const admin = instance.admin();
+      //below is query string used to update database, does not need to be ordered e.g. (partition_43 = 0, partition_0 = 17...)
+      let setString = '';
+      admin.connect();
+      admin
+        .fetchTopicOffsets(topic)
+        .then((result) => {
+          result.forEach((el) => {
+            //adding each partitions value to the set string
+            setString += `partition_${el.partition} = ${el.offset},`;
+          });
+        })
+        .then(() => {
+          //!!important!! slicing off last comma, which will throw a SQL syntax error
+          setString = setString.slice(0, setString.length - 1);
+          open({
+            filename: '/tmp/database.db',
+            driver: sqlite3.Database,
+          })
+            .then((db) => {
+              db.exec(
+                `UPDATE ${bootstrapSanitized} SET ${setString} WHERE topic='${topic}';`
+              );
+              return db;
+            })
+            //here we grab topic data from sqldb (after updated)
+            .then((db) => {
+              db.all(
+                `SELECT * FROM ${bootstrapSanitized} WHERE topic='${topic}'`
+              ).then((result) => {
+                //new arr which holds the correctly formated data for d3
+                const arr: { time: number; value: number }[] = [];
+                Object.keys(result[0]).forEach((el) => {
+                  if (el !== 'topic') {
+                    arr.push({
+                      //slicing off first part of colname and turning into number (for d3) (partition_1 -> 1)
+                      time: Number(el.slice(10)),
+                      value: result[0][el],
+                    });
+                  }
+                });
+                res.status(200).json(arr);
+              });
+            });
+        });
+    } catch (error) {
+      console.log(error);
+      next(error);
+    }
   },
 };
 

--- a/client/server/kafkaRouter.ts
+++ b/client/server/kafkaRouter.ts
@@ -7,6 +7,11 @@ router.use(
   kafkaController.createTable,
   kafkaController.fetchTables
 );
+router.use(
+  '/updateTables',
+  kafkaController.updateTables,
+  kafkaController.fetchTopics
+);
 router.use('/fetchTopics', kafkaController.fetchTopics);
 router.use('/fetchTables', kafkaController.fetchTables);
 router.use('/createTable', kafkaController.createTable);

--- a/client/server/server.ts
+++ b/client/server/server.ts
@@ -2,8 +2,8 @@ import createServer from './createServer';
 import { connect, ConnectOptions } from 'mongoose';
 const app = createServer();
 
-const MONGO_URI =
-  'mongodb+srv://dbUser:codesmith@cluster0.drsef.mongodb.net/saamsa?retryWrites=true&w=majority';
+const MONGO_URI = 'mongodb://127.0.0.1/testing';
+// 'mongodb+srv://dbUser:codesmith@cluster0.drsef.mongodb.net/saamsa?retryWrites=true&w=majority';
 connect(MONGO_URI, {
   useNewUrlParser: true,
   useUnifiedTopology: true,

--- a/client/server/server.ts
+++ b/client/server/server.ts
@@ -1,5 +1,7 @@
 import createServer from './createServer';
 import { connect, ConnectOptions } from 'mongoose';
+import { exec } from 'child_process';
+import path from 'path';
 const app = createServer();
 
 const MONGO_URI = 'mongodb://127.0.0.1/testing';
@@ -11,7 +13,10 @@ connect(MONGO_URI, {
 } as ConnectOptions)
   .then(() => {
     console.log('Connected to MongoDB');
-    app.listen(3001, () => console.log('server listening on port 3001 :)'));
+    app.listen(3001, () => {
+      exec(`electron ${path.resolve(__dirname, '../electron/index.js')}`);
+      console.log('server listening on port 3001 :)');
+    });
   })
   .catch((err: Error) =>
     console.log(`Error found inside the mongoose connect method: ${err}`)

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { BrowserWindow, app } from 'electron';
-import { fork } from 'child_process';
+import * as childProcess from 'child_process';
 import * as path from 'path';
 
 //so we need to compile down from ts to js upon loading app -> adding that to package.json
@@ -13,10 +13,8 @@ function createWindow() {
   win.loadFile('../../index.html');
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   createWindow();
-  const serverProcess = fork(path.resolve(__dirname, '../server/server.js'));
-
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();
   });
@@ -24,6 +22,6 @@ app.whenReady().then(() => {
   //closes process if window closed and not on MacOS (keeps in dock for Mac though, as expected for Mac UX)
   app.on('window-all-closed', () => {
     if (process.platform !== 'darwin') app.quit();
-    serverProcess.kill(0);
+    // serverProcess.kill(0);
   });
 });

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "webpack": " tsc client/index.tsx --declaration --outDir ./dist --module es2015 --jsx react --moduleResolution node && webpack && tsc ./client/server/server.ts --moduleResolution node --outDir ./dist/server --esModuleInterop true",
-    "start": "tsc index.ts --outDir ./dist/electron && electron ./dist/electron/index.js",
+    "start": "tsc index.ts --outDir ./dist/electron && node ./dist/server/server.js",
     "test": "NODE_ENV=testing jest GraphUnitTests SelectorUnitTests LoginPageUnitTests && NODE_ENV=testing jest --env=node serverUnitTests sqlUnitTests",
     "both": "npm run webpack && npm run start",
     "package": "electron-forge package",


### PR DESCRIPTION
fixes #63 
fixes #60 
fixes #52
fixes #50 

1. added even more catches in backend when calling sqlite to eliminate sqlite crashing app
2. added below functionality to topic list
- topic list now empties correctly when no broker is selected
- topic list now auto-updates every 3 seconds with any new topics added to the broker
- when adding topic with more partitions than maxPartitions on broker, sqlite recreates table with new maxPartition
- !minor bugs!
- [ ] topic list disappears for 3 seconds whenever a new table must be created
- [ ] when new table has to be created, minor express routing errors are raised (cannot set headers after res sent to client), but are not breaking/crashing app
3. changed how electron loads to first load server then load electron window so that in dev mode initial requests to backend are not refused
4. Moved intervals for auto-updating out of component classnames and into state